### PR TITLE
レスポンシブ Feature/responsive

### DIFF
--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,8 +1,7 @@
 import type {Metadata} from 'next'
 import {Noto_Sans_JP} from 'next/font/google'
 import {AppRouterCacheProvider} from '@mui/material-nextjs/v14-appRouter';
-import {CssBaseline, ThemeProvider} from "@mui/material";
-import {theme} from "@/components/theme/theme"
+import {CssBaseline} from "@mui/material";
 
 const noto = Noto_Sans_JP({
     weight: ['400', '500', '600', '700'],

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -23,10 +23,8 @@ export default function RootLayout({
         <html lang="ja">
         <body className={noto.className}>
         <AppRouterCacheProvider>
-            <ThemeProvider theme={theme}>
                 <CssBaseline/>
                 {children}
-            </ThemeProvider>
         </AppRouterCacheProvider>
         </body>
         </html>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,16 +1,39 @@
+'use client'
 import {Button, Stack, Typography} from "@mui/material";
 import LoginButton from "@/components/auth/LoginButton";
 import Image from "next/image";
 import WiderLogo from "@/components/svg/wider";
 import Link from "next/link";
 import PrivacyPolicyDrawer from "@/components/layout/privacyPolicyDrawer";
+import {useTheme} from "@mui/material/styles";
+import Logo from "@/public/logo/logo.svg";
+import * as React from "react";
 
 export default function Login() {
+    const theme = useTheme();
     return (
-        <Stack height="100vh" width="100vw" justifyContent="center" alignItems="center" sx={{background:"radial-gradient(ellipse at left, #5F6DC2, #3E4EB3)"}}>
-            <Stack justifyContent="center" alignItems="center" spacing={1.5}>
-                <Image src={"/logo/logo_admin.png"} height={"24"} width={"302"} alt={"SPORTSDAY Admin"}/>
-                <Typography pb={3} fontSize={"14px"} fontWeight={"600"} color={"#EFF0F8"}>球技大会の進行管理アプリケーション</Typography>
+        <Stack height="100vh" width="100vw" justifyContent="center" alignItems="center" sx={{background: `linear-gradient(${theme.palette.secondary.light}, ${theme.palette.secondary.dark})`,}}>
+            <Stack justifyContent="center" alignItems="center" spacing={1.5} maxWidth={"600px"} width={"100%"} px={2}>
+                <Stack
+                    direction={"row"}
+                    spacing={1}
+                    sx={{
+                        cursor: "pointer",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        color: theme.palette.text.primary,
+                        textDecoration: "none"
+                    }}
+                >
+                    <Logo width={18 * 8.45} height={18} fill={theme.palette.text.primary}/>
+                    <Typography
+                        color={"text.primary"} fontWeight={"bold"} pt={0.15}
+                        fontSize={"18px"}
+                        sx={{textTransform: "none"}}
+                    >Admin
+                    </Typography>
+                </Stack>
+                <Typography pb={3} fontSize={"20px"} fontWeight={"600"}>球技大会の進行管理アプリケーション</Typography>
                 <LoginButton/>
                 <PrivacyPolicyDrawer/>
                 <Typography fontSize={"13px"} fontWeight={"400"} color={"#9aa6e5"}>SPORTSDAYを使うにはCookieが必要です</Typography>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,9 +1,7 @@
 'use client'
 import {Button, Stack, Typography} from "@mui/material";
 import LoginButton from "@/components/auth/LoginButton";
-import Image from "next/image";
 import WiderLogo from "@/components/svg/wider";
-import Link from "next/link";
 import PrivacyPolicyDrawer from "@/components/layout/privacyPolicyDrawer";
 import {useTheme} from "@mui/material/styles";
 import Logo from "@/public/logo/logo.svg";

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -4,6 +4,7 @@ import {AppRouterCacheProvider} from '@mui/material-nextjs/v14-appRouter';
 import {CssBaseline, ThemeProvider, Box, Stack} from "@mui/material";
 import {theme} from "@/components/theme/theme"
 import {Navigation} from "@/components/layout/navigation";
+import ColorModeProvider from "@/components/theme/colorModeProvider";
 
 const noto = Noto_Sans_JP({
     weight: ['400', '500', '600', '700'],
@@ -24,7 +25,7 @@ export default function RootLayout({
         <html lang="ja">
         <body className={noto.className}>
         <AppRouterCacheProvider>
-            <ThemeProvider theme={theme}>
+            <ColorModeProvider>
                 <CssBaseline/>
                 <Box sx={{ display: 'flex' }}>
                     <Navigation/>
@@ -32,7 +33,7 @@ export default function RootLayout({
                         {children}
                     </Stack>
                 </Box>
-            </ThemeProvider>
+            </ColorModeProvider>
         </AppRouterCacheProvider>
         </body>
         </html>

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -22,20 +22,14 @@ export default function RootLayout({
     children: React.ReactNode
 }) {
     return (
-        <html lang="ja">
-        <body className={noto.className}>
-        <AppRouterCacheProvider>
-            <ColorModeProvider>
-                <CssBaseline/>
-                <Box sx={{ display: 'flex' }}>
-                    <Navigation/>
-                    <Stack minHeight="100lvh-8" width="100%" mt={8}>
-                        {children}
-                    </Stack>
-                </Box>
-            </ColorModeProvider>
-        </AppRouterCacheProvider>
-        </body>
-        </html>
+        <>
+            <CssBaseline/>
+            <Box sx={{ display: 'flex' }}>
+                <Navigation/>
+                <Stack minHeight="100lvh-8" width="100%" mt={8}>
+                    {children}
+                </Stack>
+            </Box>
+        </>
     )
 }

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -1,16 +1,6 @@
 import type {Metadata} from 'next'
-import {Noto_Sans_JP} from 'next/font/google'
-import {AppRouterCacheProvider} from '@mui/material-nextjs/v14-appRouter';
-import {CssBaseline, ThemeProvider, Box, Stack} from "@mui/material";
-import {theme} from "@/components/theme/theme"
+import {CssBaseline, Box, Stack} from "@mui/material";
 import {Navigation} from "@/components/layout/navigation";
-import ColorModeProvider from "@/components/theme/colorModeProvider";
-
-const noto = Noto_Sans_JP({
-    weight: ['400', '500', '600', '700'],
-    subsets: ['latin'],
-    variable: '--font-noto-sans-jp',
-});
 
 export const metadata: Metadata = {
     title: 'Sports-day Admin',

--- a/app/(authenticated)/loading.tsx
+++ b/app/(authenticated)/loading.tsx
@@ -12,7 +12,7 @@ export default function Loading() {
 
     return(
         <>
-            <Backdrop open={backdropOpen} sx={{backgroundColor:"rgba(239,240,248, 0.4)", zIndex: 1}}/>
+            <Backdrop open={backdropOpen} sx={{backgroundColor:"rgba(45,52,98,0.3)", zIndex: 1}}/>
             <Stack spacing={2} mx={2} my={3}>
                 <Skeleton animation="wave" variant="text" width={300} height={18} />
                 <CardBackground>

--- a/app/(authenticated)/page.tsx
+++ b/app/(authenticated)/page.tsx
@@ -1,4 +1,4 @@
-import {Breadcrumbs, Grid, Stack, Typography} from "@mui/material"
+import {Breadcrumbs, Grid, Stack, Typography, useTheme} from "@mui/material"
 import CardBackground from "@/components/layout/cardBackground"
 import CardLarge from "@/components/layout/cardLarge"
 import SportsList from "@/components/sports/sportsList"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,8 @@
 import type {Metadata} from 'next'
 import {Noto_Sans_JP} from 'next/font/google'
 import {AppRouterCacheProvider} from '@mui/material-nextjs/v14-appRouter';
-import {CssBaseline, ThemeProvider} from "@mui/material";
-import {theme} from "@/components/theme/theme"
+import {CssBaseline} from "@mui/material";
+import ColorModeProvider from "@/components/theme/colorModeProvider";
 
 const noto = Noto_Sans_JP({
     weight: ['400', '500', '600', '700'],
@@ -22,12 +22,14 @@ export default function RootLayout({
     return (
         <html lang="ja">
         <body className={noto.className}>
+
         <AppRouterCacheProvider>
-            <ThemeProvider theme={theme}>
-                <CssBaseline/>
-                {children}
-            </ThemeProvider>
+                <ColorModeProvider>
+                    <CssBaseline/>
+                    {children}
+                </ColorModeProvider>
         </AppRouterCacheProvider>
+
         </body>
         </html>
     )

--- a/components/auth/LoginButton.tsx
+++ b/components/auth/LoginButton.tsx
@@ -1,11 +1,13 @@
 'use client'
-import {Button} from "@mui/material";
+import {Button, Typography} from "@mui/material";
 import crypto from 'crypto';
 import * as querystring from "querystring";
 import {useEffect, useState} from "react";
+import {useTheme} from "@mui/material/styles";
 
 export default function LoginButton() {
     const [authorizationUrl, setAuthorizationUrl] = useState<string>('')
+    const theme = useTheme()
 
     useEffect(() => {
         const authorizationBaseUrl = process.env.NEXT_PUBLIC_OIDC_AUTHORIZE_URL
@@ -37,12 +39,14 @@ export default function LoginButton() {
     return (
         <Button
             variant="contained"
-            color="secondary"
+            color="primary"
             href={authorizationUrl}
-            sx={{py:1.5, width:"100%"}}
+            sx={{px:3, py:1.5, width:"100%", backgroundColor:`${theme.palette.text.primary}`}}
             disableElevation
         >
-            {buttonDisplayName}
+            <Typography fontSize={"14px"} color={theme.palette.background.paper}>
+                {buttonDisplayName}
+            </Typography>
         </Button>
     );
 }

--- a/components/auth/LogoutButton.tsx
+++ b/components/auth/LogoutButton.tsx
@@ -18,7 +18,7 @@ export default function LogoutButton() {
                 }}
                 sx={{width:"fit-content"}}
             >
-                <HiArrowRightOnRectangle color={"#eff0f8"}/>
+                <HiArrowRightOnRectangle color={"text.primary"}/>
             </IconButton>
         </Tooltip>
     );

--- a/components/auth/LogoutButton.tsx
+++ b/components/auth/LogoutButton.tsx
@@ -3,9 +3,11 @@ import {IconButton, Tooltip} from "@mui/material";
 import Cookies from "js-cookie";
 import {useRouter} from "next/navigation";
 import {HiArrowRightOnRectangle} from "react-icons/hi2";
+import {useTheme} from "@mui/material/styles";
 
 export default function LogoutButton() {
     const router = useRouter()
+    const theme = useTheme()
 
     return (
         <Tooltip title={"ログアウト"}>
@@ -18,7 +20,7 @@ export default function LogoutButton() {
                 }}
                 sx={{width:"fit-content"}}
             >
-                <HiArrowRightOnRectangle color={"text.primary"}/>
+                <HiArrowRightOnRectangle color={theme.palette.text.secondary}/>
             </IconButton>
         </Tooltip>
     );

--- a/components/layout/buttonLarge.tsx
+++ b/components/layout/buttonLarge.tsx
@@ -1,4 +1,4 @@
-import {Avatar, Button, Stack, Grid} from "@mui/material";
+import {Avatar, Button, Stack, Grid, Typography} from "@mui/material";
 import React, {ReactNode} from "react";
 
 type ButtonLargeProps = {
@@ -11,6 +11,7 @@ export const ButtonLarge: React.FC<ButtonLargeProps> = ({img, children, link})=>
     return(
         <Grid item xs={12} sm={6} md={4} lg={3}>
             <Button
+                color={"secondary"}
                 variant={"contained"}
                 sx={{width:"100%"}}
                 href={link}
@@ -27,7 +28,9 @@ export const ButtonLarge: React.FC<ButtonLargeProps> = ({img, children, link})=>
                         src={img}
                     >
                     </Avatar>}
-                    {children}
+                    <Typography fontSize={"inherit"} color={"text.primary"}>
+                        {children}
+                    </Typography>
                 </Stack>
             </Button>
         </Grid>

--- a/components/layout/cardBackground.tsx
+++ b/components/layout/cardBackground.tsx
@@ -1,5 +1,6 @@
-import {Button, Card, Stack, Typography} from "@mui/material";
+import {Button, Card, Stack, Typography, useTheme} from "@mui/material";
 import React, {ReactNode} from 'react';
+import {red} from "@mui/material/colors";
 
 type CardProps = {
     title?: string;
@@ -10,18 +11,27 @@ type CardProps = {
 };
 
 const CardBackground: React.FC<CardProps> = ({title, button, link, children, onClick}) => {
+
     return (
         <>
-            <Card sx={{py: 2, px: 2}}>
+            <Card
+                sx={{
+                    py: 2, px: 2,
+                    backgroundImage:`linear-gradient(rgba(105,112,164,0), rgba(47,60,140,0.08))`
+                }}
+            >
                 <Stack pb={2} spacing={1} direction={"row"} justifyContent={"flex-start"} alignItems="center">
-                    {title && <Typography color={"primary.light"}>{title}</Typography>}
+                    {title && <Typography color={"text.primary"}>{title}</Typography>}
                     {button &&
                         <Button
+                            color={"secondary"}
                             variant={"contained"}
                             href={link}
                             onClick={onClick}
                         >
-                            {button}
+                            <Typography fontSize={"inherit"} color={"text.primary"}>
+                                {button}
+                            </Typography>
                         </Button>
                     }
                 </Stack>

--- a/components/layout/cardLarge.tsx
+++ b/components/layout/cardLarge.tsx
@@ -9,10 +9,10 @@ type CardProps = {
 const CardLarge: React.FC<CardProps> = ({ children }) => {
     return (
         <>
-            <Card sx={{py:1.5, px:2, backgroundColor:"primary.main", color:"secondary.main"}}>
+            <Card sx={{py:1.5, px:2, backgroundColor:"secondary.main", color:"text.primary"}}>
                 <Stack spacing={1} direction={"row"} justifyContent={"flex-start"} alignItems="center">
-                    <Avatar sx={{height:"1.5em", width:"1.5em", backgroundColor:"primary.dark"}}>
-                        <HiMegaphone/>
+                    <Avatar sx={{height:"1.5em", width:"1.5em", backgroundColor:"text.secondary"}}>
+                        <HiMegaphone color={"secondary.main"}/>
                     </Avatar>
                     <Typography>{children}</Typography>
                 </Stack>

--- a/components/layout/logo.tsx
+++ b/components/layout/logo.tsx
@@ -1,0 +1,15 @@
+import Image from "next/image";
+import PropTypes from "prop-types";
+
+export const SDLogo = (props: any) => {
+    const {w} = props;
+    return (
+        <>
+            <Image src={"public/logo.svg"} alt="logo" height={w*8.45} width={w} priority />
+        </>
+    );
+};
+
+SDLogo.propTypes = {
+    w: PropTypes.object
+};

--- a/components/layout/navPrivacyPolicyDrawer.tsx
+++ b/components/layout/navPrivacyPolicyDrawer.tsx
@@ -3,9 +3,11 @@ import {Container, Button, AppBar, Box, SwipeableDrawer, IconButton, Tooltip, Bo
 import React from 'react';
 import {HiBuildingLibrary, HiXMark} from "react-icons/hi2";
 import PrivacyPolicy from "@/components/layout/privacyPolicy";
+import {useTheme} from "@mui/material/styles";
 
 const NavPrivacyPolicyDrawer = () => {
     const [open, setOpen] = React.useState(false);
+    const theme = useTheme()
 
     const toggleDrawer = (newOpen: boolean) => () => {
         setOpen(newOpen);
@@ -59,7 +61,7 @@ const NavPrivacyPolicyDrawer = () => {
                 <IconButton
                     onClick={toggleDrawer(true)}
                 >
-                    <HiBuildingLibrary color={"text.primary"}/>
+                    <HiBuildingLibrary color={theme.palette.text.secondary}/>
                 </IconButton>
             </Tooltip>
             <SwipeableDrawer

--- a/components/layout/navPrivacyPolicyDrawer.tsx
+++ b/components/layout/navPrivacyPolicyDrawer.tsx
@@ -59,7 +59,7 @@ const NavPrivacyPolicyDrawer = () => {
                 <IconButton
                     onClick={toggleDrawer(true)}
                 >
-                    <HiBuildingLibrary color={"#eff0f8"}/>
+                    <HiBuildingLibrary color={"text.primary"}/>
                 </IconButton>
             </Tooltip>
             <SwipeableDrawer

--- a/components/layout/navPrivacyPolicyDrawer.tsx
+++ b/components/layout/navPrivacyPolicyDrawer.tsx
@@ -1,5 +1,5 @@
 'use client'
-import {Container, Button, AppBar, Box, SwipeableDrawer, IconButton, Tooltip, BottomNavigation,} from "@mui/material";
+import {Container, Button, Box, SwipeableDrawer, IconButton, Tooltip, BottomNavigation,} from "@mui/material";
 import React from 'react';
 import {HiBuildingLibrary, HiXMark} from "react-icons/hi2";
 import PrivacyPolicy from "@/components/layout/privacyPolicy";

--- a/components/layout/navigation.tsx
+++ b/components/layout/navigation.tsx
@@ -1,9 +1,8 @@
 'use client'
 import * as React from 'react'
 import {AppBar, Box, Button, Drawer, IconButton, Stack, SvgIcon, Toolbar, Tooltip, Typography} from "@mui/material";
-import {createTheme} from "@mui/material/styles";
-
-import Image from "next/image";
+import {useTheme} from "@mui/material/styles";
+import Logo from "@/public/logo/logo.svg";
 import {
     HiHome,
     HiMegaphone,
@@ -21,7 +20,7 @@ import LogoutButton from "@/components/auth/LogoutButton";
 
 
 export const Navigation = () => {
-    const theme = createTheme();
+    const theme = useTheme();
     const drawerWidth = 303;
     const buttonPadding = 1.3;
     const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -41,8 +40,7 @@ export const Navigation = () => {
     };
 
     const drawer = (
-        <Box px={2} my={8} sx={{overflow: 'auto'}}>
-
+        <Box px={2} mt={8} sx={{overflow: 'auto'}}>
             <Stack spacing={1} py={3}>
                 <Typography sx={{pl: 2.5}}>全体</Typography>
                 <Button
@@ -212,7 +210,7 @@ export const Navigation = () => {
                 <LogoutButton/>
                 <Tooltip title={"GitHub"} arrow>
                     <IconButton href={"https://github.com/Sports-day/sports-day-admin"} target={"_blank"}>
-                        <SiGithub color={"text.primary"}/>
+                        <SiGithub color={theme.palette.text.secondary}/>
                     </IconButton>
                 </Tooltip>
                 <NavPrivacyPolicyDrawer/>
@@ -233,19 +231,37 @@ export const Navigation = () => {
                     zIndex: (theme) => theme.zIndex.drawer + 1,
                     background: "rgba(62,78,179,0.2)",
                     backdropFilter: 'blur(30px)',
+                    color: theme.palette.text.primary,
                 }}>
                 <Toolbar>
                     <IconButton
                         aria-label="open drawer"
                         edge="start"
                         onClick={handleDrawerToggle}
-                        sx={{mr: 2, display: {sm: 'none'}}}
+                        sx={{mx: 0, display: {sm: 'none'}}}
                     >
-                        <HiBars2 color={"text.primary"}/>
+                        <HiBars2 color={theme.palette.text.primary}/>
                     </IconButton>
-                    <Link href={"/"}>
-                        <Image src={"/logo/logo_admin.png"} height={"20"} width={"252"}  alt={"SPORTSDAY Admin"}/>
-                    </Link>
+                    <Button href={"/"}>
+                        <Stack
+                            direction={"row"}
+                            spacing={1}
+                            sx={{
+                                cursor: "pointer",
+                                justifyContent: "center",
+                                alignItems: "center",
+                                color: theme.palette.text.primary,
+                                textDecoration: "none"
+                            }}
+                        >
+                            <Logo width={16 * 8.45} height={16} fill={theme.palette.text.primary}/>
+                            <Typography
+                                color={"text.primary"} fontWeight={"bold"} pt={0.15}
+                                sx={{textTransform: "none"}}
+                            >Admin
+                            </Typography>
+                        </Stack>
+                    </Button>
                 </Toolbar>
             </AppBar>
             <Box

--- a/components/layout/navigation.tsx
+++ b/components/layout/navigation.tsx
@@ -49,6 +49,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -65,6 +66,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -81,6 +83,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -100,6 +103,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/sports"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -115,6 +119,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/locations"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -134,6 +139,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/users"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -149,6 +155,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/teams"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -164,6 +171,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/roles"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -179,6 +187,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/tags"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">
@@ -194,6 +203,7 @@ export const Navigation = () => {
                     sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
                     component={Link}
                     href={"/images"}
+                    onClick={handleDrawerToggle}
                 >
                     <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
                            alignItems="center">

--- a/components/layout/navigation.tsx
+++ b/components/layout/navigation.tsx
@@ -1,6 +1,8 @@
 'use client'
 import * as React from 'react'
 import {AppBar, Box, Button, Drawer, IconButton, Stack, SvgIcon, Toolbar, Tooltip, Typography} from "@mui/material";
+import {createTheme} from "@mui/material/styles";
+
 import Image from "next/image";
 import {
     HiHome,
@@ -9,7 +11,7 @@ import {
     HiUser,
     HiUserGroup,
     HiTrophy,
-    HiMapPin, HiIdentification, HiMiniTag, HiPhoto
+    HiMapPin, HiIdentification, HiMiniTag, HiPhoto, HiBars2
 } from "react-icons/hi2";
 import {SiGithub} from "react-icons/si";
 import WiderLogo from "@/components/svg/wider";
@@ -17,9 +19,211 @@ import Link from "next/link"
 import NavPrivacyPolicyDrawer from "@/components/layout/navPrivacyPolicyDrawer";
 import LogoutButton from "@/components/auth/LogoutButton";
 
+
 export const Navigation = () => {
+    const theme = createTheme();
     const drawerWidth = 303;
     const buttonPadding = 1.3;
+    const [mobileOpen, setMobileOpen] = React.useState(false);
+    const [isClosing, setIsClosing] = React.useState(false);
+
+    const handleDrawerClose = () => {
+        setIsClosing(true);
+        setMobileOpen(false);
+    }
+    const handleDrawerTransitionEnd = () => {
+        setIsClosing(false);
+    }
+    const handleDrawerToggle = () => {
+        if (!isClosing) {
+            setMobileOpen(!mobileOpen);
+        }
+    };
+
+    const drawer = (
+        <Box px={2} my={8} sx={{overflow: 'auto'}}>
+
+            <Stack spacing={1} py={3}>
+                <Typography sx={{pl: 2.5}}>全体</Typography>
+                <Button
+                    color={"secondary"}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiHome/>
+                        </SvgIcon>
+                        <Typography>ホーム</Typography>
+                    </Stack>
+                </Button>
+                <Button
+                    color={"secondary"}
+                    disabled={true}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiMegaphone/>
+                        </SvgIcon>
+                        <Typography>お知らせ</Typography>
+                    </Stack>
+                </Button>
+                <Button
+                    color={"secondary"}
+                    disabled={true}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiMiniNewspaper/>
+                        </SvgIcon>
+                        <Typography>予定とルール</Typography>
+                    </Stack>
+                </Button>
+            </Stack>
+
+            <Stack spacing={1} pb={3}>
+                <Typography sx={{pl: 2.5}}>スポーツ</Typography>
+                <Button
+                    color={"secondary"}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/sports"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiTrophy/>
+                        </SvgIcon>
+                        <Typography>競技</Typography>
+                    </Stack>
+                </Button>
+                <Button
+                    color={"secondary"}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/locations"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiMapPin/>
+                        </SvgIcon>
+                        <Typography>場所</Typography>
+                    </Stack>
+                </Button>
+            </Stack>
+
+            <Stack spacing={1} pb={3}>
+                <Typography sx={{pl: 2.5}}>情報</Typography>
+                <Button
+                    color={"secondary"}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/users"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiUser/>
+                        </SvgIcon>
+                        <Typography>ユーザー</Typography>
+                    </Stack>
+                </Button>
+                <Button
+                    color={"secondary"}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/teams"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiUserGroup/>
+                        </SvgIcon>
+                        <Typography>チーム</Typography>
+                    </Stack>
+                </Button>
+                <Button
+                    color={"secondary"}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/roles"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiIdentification/>
+                        </SvgIcon>
+                        <Typography>権限</Typography>
+                    </Stack>
+                </Button>
+                <Button
+                    color={"secondary"}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/tags"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiMiniTag/>
+                        </SvgIcon>
+                        <Typography>タグ</Typography>
+                    </Stack>
+                </Button>
+                <Button
+                    color={"secondary"}
+                    variant={"contained"}
+                    sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
+                    component={Link}
+                    href={"/images"}
+                >
+                    <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
+                           alignItems="center">
+                        <SvgIcon fontSize={"small"}>
+                            <HiPhoto/>
+                        </SvgIcon>
+                        <Typography>画像</Typography>
+                    </Stack>
+                </Button>
+            </Stack>
+
+            <Stack spacing={1} width={"100%"} direction={"row"} justifyContent={"space-around"}
+                   alignItems="center">
+                <LogoutButton/>
+                <Tooltip title={"GitHub"} arrow>
+                    <IconButton href={"https://github.com/Sports-day/sports-day-admin"} target={"_blank"}>
+                        <SiGithub color={"text.primary"}/>
+                    </IconButton>
+                </Tooltip>
+                <NavPrivacyPolicyDrawer/>
+            </Stack>
+            <Stack width={"100%"} py={2} justifyContent="center" alignItems="center" direction={"row"}
+                   spacing={0.5}>
+                <Typography fontWeight={"600"} color={"#9aa6e5"}>(C)2024</Typography>
+                <WiderLogo/>
+            </Stack>
+        </Box>
+    );
 
     return (
         <>
@@ -27,203 +231,55 @@ export const Navigation = () => {
                 position="fixed"
                 sx={{
                     zIndex: (theme) => theme.zIndex.drawer + 1,
-                    background: "rgba(62,78,179,0.8)",
+                    background: "rgba(62,78,179,0.2)",
                     backdropFilter: 'blur(30px)',
                 }}>
                 <Toolbar>
+                    <IconButton
+                        aria-label="open drawer"
+                        edge="start"
+                        onClick={handleDrawerToggle}
+                        sx={{mr: 2, display: {sm: 'none'}}}
+                    >
+                        <HiBars2 color={"text.primary"}/>
+                    </IconButton>
                     <Link href={"/"}>
-                        <Image src={"/logo/logo_admin.png"} height={"20"} width={"252"} alt={"SPORTSDAY Admin"}/>
+                        <Image src={"/logo/logo_admin.png"} height={"20"} width={"252"}  alt={"SPORTSDAY Admin"}/>
                     </Link>
                 </Toolbar>
             </AppBar>
-            <Drawer
-                variant="permanent"
-                PaperProps={{
-                    sx: {
-                        backgroundColor: "#7F8CD6",
-                        color: "#fff",
-                        pt: 8
-                    }
-                }}
-                sx={{
-                    width: drawerWidth,
-                    flexShrink: 0,
-                    [`& .MuiDrawer-paper`]: {width: drawerWidth, boxSizing: 'border-box'},
-                }}
+            <Box
+                component="nav"
+                sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
+                aria-label="mailbox folders"
             >
-                <Box px={2} sx={{overflow: 'auto'}}>
-
-                    <Stack spacing={1} py={3}>
-                        <Typography sx={{pl: 2.5}}>全体</Typography>
-                        <Button
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiHome/>
-                                </SvgIcon>
-                                <Typography>ホーム</Typography>
-                            </Stack>
-                        </Button>
-                        <Button
-                            disabled={true}
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiMegaphone/>
-                                </SvgIcon>
-                                <Typography>お知らせ</Typography>
-                            </Stack>
-                        </Button>
-                        <Button
-                            disabled={true}
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiMiniNewspaper/>
-                                </SvgIcon>
-                                <Typography>予定とルール</Typography>
-                            </Stack>
-                        </Button>
-                    </Stack>
-
-                    <Stack spacing={1} pb={3}>
-                        <Typography sx={{pl: 2.5}}>スポーツ</Typography>
-                        <Button
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/sports"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiTrophy/>
-                                </SvgIcon>
-                                <Typography>競技</Typography>
-                            </Stack>
-                        </Button>
-                        <Button
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/locations"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiMapPin/>
-                                </SvgIcon>
-                                <Typography>場所</Typography>
-                            </Stack>
-                        </Button>
-                    </Stack>
-
-                    <Stack spacing={1} pb={3}>
-                        <Typography sx={{pl: 2.5}}>情報</Typography>
-                        <Button
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/users"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiUser/>
-                                </SvgIcon>
-                                <Typography>ユーザー</Typography>
-                            </Stack>
-                        </Button>
-                        <Button
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/teams"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiUserGroup/>
-                                </SvgIcon>
-                                <Typography>チーム</Typography>
-                            </Stack>
-                        </Button>
-                        <Button
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/roles"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiIdentification/>
-                                </SvgIcon>
-                                <Typography>権限</Typography>
-                            </Stack>
-                        </Button>
-                        <Button
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/tags"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiMiniTag/>
-                                </SvgIcon>
-                                <Typography>タグ</Typography>
-                            </Stack>
-                        </Button>
-                        <Button
-                            variant={"contained"}
-                            sx={{py: buttonPadding, width: "100%", fontWeight: "600"}}
-                            component={Link}
-                            href={"/images"}
-                        >
-                            <Stack spacing={1} mx={1} width={"100%"} direction={"row"} justifyContent={"flex-start"}
-                                   alignItems="center">
-                                <SvgIcon fontSize={"small"}>
-                                    <HiPhoto/>
-                                </SvgIcon>
-                                <Typography>画像</Typography>
-                            </Stack>
-                        </Button>
-                    </Stack>
-
-                    <Stack spacing={1} width={"100%"} direction={"row"} justifyContent={"space-around"}
-                           alignItems="center">
-                        <LogoutButton/>
-                        <Tooltip title={"GitHub"} arrow>
-                            <IconButton href={"https://github.com/Sports-day/sports-day-admin"} target={"_blank"}>
-                                <SiGithub color={"#eff0f8"}/>
-                            </IconButton>
-                        </Tooltip>
-                        <NavPrivacyPolicyDrawer/>
-                    </Stack>
-                    <Stack width={"100%"} py={2} justifyContent="center" alignItems="center" direction={"row"}
-                           spacing={0.5}>
-                        <Typography fontWeight={"600"} color={"#9aa6e5"}>(C)2024</Typography>
-                        <WiderLogo/>
-                    </Stack>
-                </Box>
-            </Drawer>
+                {/* The implementation can be swapped with js to avoid SEO duplication of links. */}
+                <Drawer
+                    variant="temporary"
+                    open={mobileOpen}
+                    onTransitionEnd={handleDrawerTransitionEnd}
+                    onClose={handleDrawerClose}
+                    ModalProps={{
+                        keepMounted: true, // Better open performance on mobile.
+                    }}
+                    sx={{
+                        display: { xs: 'block', sm: 'none' },
+                        '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+                    }}
+                >
+                    {drawer}
+                </Drawer>
+                <Drawer
+                    variant="permanent"
+                    sx={{
+                        display: { xs: 'none', sm: 'block' },
+                        '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+                    }}
+                    open
+                >
+                    {drawer}
+                </Drawer>
+            </Box>
         </>
     )
 }

--- a/components/layout/privacyPolicyDrawer.tsx
+++ b/components/layout/privacyPolicyDrawer.tsx
@@ -49,7 +49,7 @@ const PrivacyPolicyDrawer = () => {
         <>
             <Button
                 variant="contained"
-                color="primary"
+                color="secondary"
                 sx={{py:1.5, width:"100%"}}
                 disableElevation
                 onClick={toggleDrawer(true)}

--- a/components/league/table/leagueTable.tsx
+++ b/components/league/table/leagueTable.tsx
@@ -1,6 +1,6 @@
 import {Game, gameFactory} from "@/src/models/GameModel";
 import {Sport} from "@/src/models/SportModel";
-import {Alert, Stack} from "@mui/material";
+import {Alert, Box, Container, Stack, Typography} from "@mui/material";
 import {ReactNode} from "react";
 import TeamCell from "@/components/league/table/teamCell";
 import SlashCell from "@/components/league/table/slashCell";
@@ -161,13 +161,12 @@ export default async function LeagueTable(props: LeagueTableProps) {
                 )
             }
 
-            <Stack
-                spacing={0}
-                direction={"row"}
-                overflow={"auto"}
-            >
-                {cells}
-            </Stack>
+            <Box width={"100%"} maxWidth={"100%"} sx={{overflow:"scroll"}}>
+                {/*maxWidth=1pxでなぜ動くかわからない*/}
+                <Stack direction={"row"} maxWidth={"1px"}>
+                    {cells}
+                </Stack>
+            </Box>
         </Stack>
     )
 }

--- a/components/league/table/leagueTable.tsx
+++ b/components/league/table/leagueTable.tsx
@@ -1,6 +1,6 @@
 import {Game, gameFactory} from "@/src/models/GameModel";
 import {Sport} from "@/src/models/SportModel";
-import {Alert, Box, Container, Stack, Typography} from "@mui/material";
+import {Alert, Box, Stack} from "@mui/material";
 import {ReactNode} from "react";
 import TeamCell from "@/components/league/table/teamCell";
 import SlashCell from "@/components/league/table/slashCell";

--- a/components/league/table/matchCell.tsx
+++ b/components/league/table/matchCell.tsx
@@ -26,6 +26,8 @@ export default function MatchCell(props: MatchCellProps) {
                 alignItems={"center"}
                 justifyContent={"center"}
                 display={"flex"}
+                color={"text.primary"}
+                bgcolor={"secondary.main"}
             >
                 <Typography>
                     エラー
@@ -44,6 +46,8 @@ export default function MatchCell(props: MatchCellProps) {
             alignItems={"center"}
             justifyContent={"center"}
             display={"flex"}
+            color={"text.primary"}
+            bgcolor={"secondary.main"}
         >
             <Typography>
                 {leftTeam.name} vs {rightTeam.name}

--- a/components/league/table/slashCell.tsx
+++ b/components/league/table/slashCell.tsx
@@ -7,7 +7,8 @@ export default function SlashCell() {
             height={100}
             width={200}
             border={1}
-            bgcolor={"#d3d3d3"}
+            bgcolor={"background.paper"}
+            color={"text.disabled"}
         >
         </Box>
     )

--- a/components/league/table/teamCell.tsx
+++ b/components/league/table/teamCell.tsx
@@ -19,6 +19,8 @@ export default function TeamCell(props: TeamCellProps) {
             alignItems={"center"}
             justifyContent={"center"}
             display={"flex"}
+            color={"text.primary"}
+            bgcolor={"secondary.main"}
         >
             <Typography>
                 {props.team.name}

--- a/components/match/matchCard.tsx
+++ b/components/match/matchCard.tsx
@@ -1,5 +1,5 @@
 import {Grid, Button, Avatar, Chip, Stack, Tooltip, Divider} from "@mui/material";
-import {HiClock, HiFlag, HiMapPin, HiTableCells, HiUserGroup} from "react-icons/hi2";
+import {HiClock, HiFlag, HiMapPin, HiTableCells, HiTrophy, HiUserGroup} from "react-icons/hi2";
 import {Match} from "@/src/models/MatchModel";
 import {sportFactory} from "@/src/models/SportModel";
 import {gameFactory} from "@/src/models/GameModel";
@@ -24,6 +24,7 @@ export default async function MatchCard(props: MatchCardProps) {
     return (
         <Grid item xs={12} sm={6} md={4} lg={3}>
             <Button
+                color={"secondary"}
                 variant={"contained"}
                 sx={{
                     width: "100%",
@@ -42,15 +43,15 @@ export default async function MatchCard(props: MatchCardProps) {
                     <Stack direction={"row"} spacing={0.1}>
                         <Tooltip title={`競技 | ${sport.name}`} placement={"top"} arrow>
                             <Chip
-                                color="primary"
+                                color="secondary"
                                 size={"small"}
-                                avatar={<Avatar></Avatar>}
+                                avatar={<Avatar><HiTrophy/></Avatar>}
                             />
                         </Tooltip>
 
                         <Tooltip title={`試合会場 | ${location?.name ?? "未登録"}`} placement={"top"} arrow>
                             <Chip
-                                color="primary"
+                                color="secondary"
                                 size={"small"}
                                 icon={<HiMapPin/>}
                             />
@@ -58,7 +59,7 @@ export default async function MatchCard(props: MatchCardProps) {
 
                         <Tooltip title={`試合開始時刻 | ${formattedDate}`} placement={"top"} arrow>
                             <Chip
-                                color="primary"
+                                color="secondary"
                                 label={formattedDate}
                                 size={"small"}
                                 icon={<HiClock/>}
@@ -71,9 +72,9 @@ export default async function MatchCard(props: MatchCardProps) {
                     <Stack
                         spacing={1}
                         width={"100%"}
+                        bgcolor={"secondary.dark"}
                         sx={{
                             borderRadius: "10px",
-                            backgroundColor: "#7f8cd6",
                             p: 1.5,
                             overflow: "auto"
                         }}
@@ -88,7 +89,7 @@ export default async function MatchCard(props: MatchCardProps) {
                             <Tooltip title={"リーグ"} placement={"top"} arrow>
                                 <Chip
                                     sx={{px: 0.5}}
-                                    color="info"
+                                    color="secondary"
                                     label={game.name ?? "不明"}
                                     icon={<HiTableCells/>}
                                 />
@@ -97,7 +98,7 @@ export default async function MatchCard(props: MatchCardProps) {
                             <Tooltip title={"審判のチーム"} placement={"top"} arrow>
                                 <Chip
                                     sx={{px: 0.5}}
-                                    color="info"
+                                    color="secondary"
                                     label={judgeTeam?.name ?? "未登録"}
                                     icon={<HiFlag/>}
                                 />
@@ -112,7 +113,7 @@ export default async function MatchCard(props: MatchCardProps) {
                             <Tooltip title={"対戦するチーム"} placement={"top"} arrow>
                                 <Chip
                                     sx={{px: 0.5}}
-                                    color="info"
+                                    color="secondary"
                                     label={`${leftTeam?.name ?? "未登録"} vs ${rightTeam?.name ?? "未登録"}`}
                                     icon={<HiUserGroup/>}
                                 />

--- a/components/match/matchEditor.tsx
+++ b/components/match/matchEditor.tsx
@@ -33,6 +33,7 @@ import Link from "next/link"
 import dayjs, {Dayjs} from "dayjs";
 import {AdapterDayjs} from "@mui/x-date-pickers/AdapterDayjs";
 import {DateTimePicker, LocalizationProvider} from "@mui/x-date-pickers";
+import Grid from "@mui/material/Grid";
 
 export type MatchEditorProps = {
     sport: Sport
@@ -212,7 +213,10 @@ export default function MatchEditor(props: MatchEditorProps) {
                       variant={"outlined"}>
                     <Stack mx={2} my={2} spacing={2} direction={"column"}>
 
-                        <Stack direction={"row"} spacing={1} overflow={"scrollable"}>
+                        <Stack
+                            direction={"row"} spacing={1}
+                            sx={{overflow:"auto"}}
+                        >
                             <Chip
                                 label={`審判：${judgeTeamName}`}
                                 avatar={<Avatar><HiFlag/></Avatar>} color={"secondary"}
@@ -229,91 +233,102 @@ export default function MatchEditor(props: MatchEditorProps) {
 
                         <Divider/>
 
-                        <Stack width={"100%"} maxWidth={"md"} direction={"row"} m={2} spacing={1}
-                               alignItems={"end"}>
-                            <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"}
-                                   sx={{
-                                       borderRadius: "12px",
-                                       backgroundColor: "rgba(49,119,44,0.05)",
-                                       p: 2
-                                   }}
-                            >
-                                <Typography fontWeight={"600"}>{leftTeamName}のスコア</Typography>
-                                <TextField
-                                    fullWidth
-                                    color={"success"}
-                                    hiddenLabel={true}
-                                    id="outlined-size-small"
-                                    placeholder="左チームのスコア"
-                                    inputRef={leftScoreRef}
-                                    defaultValue={props.match.leftScore}
-                                    onChange={handleCompare}
-                                    error={scoreError}
-                                    helperText={scoreError ? "スコアを半角数字で入力してください" : ""}
-                                />
-                            </Stack>
-                            <Typography pb={2}>
-                                VS
-                            </Typography>
-                            <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"}
-                                   sx={{
-                                       borderRadius: "12px",
-                                       backgroundColor: "rgba(162,31,31,0.05)",
-                                       p: 2
-                                   }}
-                            >
-                                <Typography fontWeight={"600"}>{rightTeamName}のスコア</Typography>
-                                <TextField
-                                    fullWidth
-                                    color={"error"}
-                                    hiddenLabel={true}
-                                    id="outlined-size-small"
-                                    placeholder="右チームのスコア"
-                                    inputRef={rightScoreRef}
-                                    defaultValue={props.match.rightScore}
-                                    onChange={handleCompare}
-                                    error={scoreError}
-                                    helperText={scoreError ? "スコアを半角数字で入力してください" : ""}
-                                />
-                            </Stack>
-                        </Stack>
+                        <Grid container spacing={0}>
+                            <Grid item xs={12} sm={5.5}>
+                                <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"}
+                                       sx={{
+                                           borderRadius: "12px",
+                                           backgroundColor: "rgba(49,119,44,0.05)",
+                                           p: 2
+                                       }}
+                                >
+                                    <Typography fontWeight={"600"}>{leftTeamName}のスコア</Typography>
+                                    <TextField
+                                        fullWidth
+                                        color={"success"}
+                                        hiddenLabel={true}
+                                        id="outlined-size-small"
+                                        placeholder="左チームのスコア"
+                                        inputRef={leftScoreRef}
+                                        defaultValue={props.match.leftScore}
+                                        onChange={handleCompare}
+                                        error={scoreError}
+                                        helperText={scoreError ? "スコアを半角数字で入力してください" : ""}
+                                    />
+                                </Stack>
+                            </Grid>
+                            <Grid item xs={12} sm={1}>
+                                <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"}>
+                                    <Typography py={2}>
+                                        VS
+                                    </Typography>
+                                </Stack>
+                            </Grid>
+                            <Grid item xs={12} sm={5.5}>
+                                <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"}
+                                       sx={{
+                                           borderRadius: "12px",
+                                           backgroundColor: "rgba(162,31,31,0.05)",
+                                           p: 2
+                                       }}
+                                >
+                                    <Typography fontWeight={"600"}>{rightTeamName}のスコア</Typography>
+                                    <TextField
+                                        fullWidth
+                                        color={"error"}
+                                        hiddenLabel={true}
+                                        id="outlined-size-small"
+                                        placeholder="右チームのスコア"
+                                        inputRef={rightScoreRef}
+                                        defaultValue={props.match.rightScore}
+                                        onChange={handleCompare}
+                                        error={scoreError}
+                                        helperText={scoreError ? "スコアを半角数字で入力してください" : ""}
+                                    />
+                                </Stack>
+                            </Grid>
+                        </Grid>
 
                         <Divider/>
 
-                        <Stack width={"100%"} maxWidth={"md"} direction={"row"} m={2} pb={3} spacing={1}
-                               alignItems={"end"}>
-                            <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"}>
-                                <Typography>勝ったのは</Typography>
-                                <ToggleButtonGroup
-                                    fullWidth
-                                    color={"info"}
-                                    value={matchResult}
-                                    exclusive
-                                    onChange={handleResultChange}
-                                    aria-label="Platform"
-                                >
-                                    <ToggleButton value="left_win" color={"success"}>{leftTeamName}</ToggleButton>
-                                    <ToggleButton value="draw">引き分け</ToggleButton>
-                                    <ToggleButton value="right_win" color={"error"}>{rightTeamName}</ToggleButton>
-                                </ToggleButtonGroup>
-                            </Stack>
-                            <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"}>
-                                <Typography>試合の状態</Typography>
-                                <ToggleButtonGroup
-                                    fullWidth
-                                    color={"primary"}
-                                    value={matchStatus}
-                                    exclusive
-                                    onChange={handleStatusChange}
-                                    aria-label="Platform"
-                                >
-                                    <ToggleButton value={"cancelled"} color={"error"}>中止</ToggleButton>
-                                    <ToggleButton value="standby" color={"success"}>スタンバイ</ToggleButton>
-                                    <ToggleButton value="in_progress" color={"warning"}>進行中</ToggleButton>
-                                    <ToggleButton value="finished" color={"info"}>完了</ToggleButton>
-                                </ToggleButtonGroup>
-                            </Stack>
-                        </Stack>
+                        <Grid container>
+                            <Grid item xs={12} sm={5.8}>
+                                <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"} mb={1}>
+                                    <Typography>勝ったのは</Typography>
+                                    <ToggleButtonGroup
+                                        fullWidth
+                                        color={"info"}
+                                        value={matchResult}
+                                        exclusive
+                                        onChange={handleResultChange}
+                                        aria-label="Platform"
+                                    >
+                                        <ToggleButton value="left_win" color={"success"}>{leftTeamName}</ToggleButton>
+                                        <ToggleButton value="draw">引き分け</ToggleButton>
+                                        <ToggleButton value="right_win" color={"error"}>{rightTeamName}</ToggleButton>
+                                    </ToggleButtonGroup>
+                                </Stack>
+                            </Grid>
+                            <Grid item xs={0} sm={0.4}></Grid>
+                            <Grid item xs={12} sm={5.8}>
+                                <Stack width={"100%"} direction={"column"} spacing={1} alignItems={"center"}>
+                                    <Typography>試合の状態</Typography>
+                                    <ToggleButtonGroup
+                                        fullWidth
+                                        color={"primary"}
+                                        value={matchStatus}
+                                        exclusive
+                                        onChange={handleStatusChange}
+                                        aria-label="Platform"
+                                    >
+                                        <ToggleButton value={"cancelled"} color={"error"}>中止</ToggleButton>
+                                        <ToggleButton value="standby" color={"success"}>スタンバイ</ToggleButton>
+                                        <ToggleButton value="in_progress" color={"warning"}>進行中</ToggleButton>
+                                        <ToggleButton value="finished" color={"info"}>完了</ToggleButton>
+                                    </ToggleButtonGroup>
+                                </Stack>
+                            </Grid>
+                        </Grid>
 
                         <Stack
                             direction={"row"}

--- a/components/theme/colorModeProvider.tsx
+++ b/components/theme/colorModeProvider.tsx
@@ -10,7 +10,7 @@ export type ColorModeProviderProps = {
 const baseTheme = {
     breakpoints: {
         values: {
-            xs: 600,
+            xs: 0,
             sm: 790,
             md: 1000,
             lg: 1200,

--- a/components/theme/colorModeProvider.tsx
+++ b/components/theme/colorModeProvider.tsx
@@ -1,0 +1,170 @@
+'use client'
+import { createTheme, ThemeProvider, useMediaQuery, PaletteMode } from '@mui/material';
+import React, { useMemo } from 'react';
+import { createShadows } from "@/components/theme/createShadows";
+
+export type ColorModeProviderProps = {
+    children: React.ReactNode;
+};
+
+const baseTheme = {
+    breakpoints: {
+        values: {
+            xs: 600,
+            sm: 790,
+            md: 1000,
+            lg: 1200,
+            xl: 1440
+        }
+    },
+    components: {
+        MuiCssBaseline: {
+            styleOverrides: {
+                '*': { boxSizing: 'border-box' },
+                html: {
+                    MozOsxFontSmoothing: 'grayscale',
+                    WebkitFontSmoothing: 'antialiased',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    minHeight: '100%',
+                    width: '100%'
+                },
+                body: {
+                    display: 'flex',
+                    flex: '1 1 auto',
+                    flexDirection: 'column',
+                    minHeight: '100%',
+                    width: '100%'
+                },
+                '#__next': {
+                    display: 'flex',
+                    flex: '1 1 auto',
+                    flexDirection: 'column',
+                    height: '100%',
+                    width: '100%'
+                },
+                'body::-webkit-scrollbar': {
+                    width: '5px',
+                    height: '8px'
+                },
+                '::-webkit-scrollbar': {
+                    width: '5px',
+                    height: '3px'
+                },
+                '::-webkit-scrollbar-track': {
+                    background: "rgba(47,57,118,0)",
+                    borderRadius:"10px"
+                },
+                '::-webkit-scrollbar-thumb': {
+                    background: "rgba(92,105,187,0.2)",
+                    borderRadius: '10px'
+                }
+            }
+        },
+        MuiSwitch: {
+            styleOverrides: {
+                root: {
+                    width: 46,
+                    height: 27,
+                    padding: 0,
+                    margin: 8,
+                },
+                switchBase: {
+                    padding: 1,
+                    '&$checked, &$colorPrimary$checked, &$colorSecondary$checked': {
+                        transform: 'translateX(16px)',
+                        color: '#fff',
+                        '& + $track': {
+                            opacity: 1,
+                            border: 'none',
+                        },
+                    },
+                },
+                thumb: { width: 24, height: 24 },
+                track: {
+                    borderRadius: 13,
+                    border: '1px solid #bdbdbd',
+                    backgroundColor: '#fafafa',
+                    opacity: 1,
+                    transition: 'background-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+                },
+            },
+        },
+        MuiButtonBase: {
+            defaultProps: { disableRipple: true }
+        },
+    },
+    shape: { borderRadius: 12 },
+    shadows: createShadows(),
+};
+
+const lightPalette = {
+    mode: 'light' as PaletteMode, // 型キャストを追加
+    primary: {
+        main: '#EFF0F8',
+        dark: '#4a5abb',
+        light: '#5f6dc2',
+    },
+    secondary: {
+        main: '#e6e9f5',
+        contrastText: '#2f3c8c',
+        dark: '#c6cbec',
+        light: '#EFF0F8',
+    },
+    background: {
+        paper: '#e1e4f6',
+        default: '#eff0f8',
+    },
+    text: {
+        primary: '#202753',
+        secondary: '#6970a4',
+        disabled: '#9fa4ce',
+    },
+    warning: {
+        main: '#b9891a',
+        contrastText: 'rgba(253,252,252,0.87)',
+    },
+    info: { main: '#5F6DC2' },
+    divider: '#7f8cd6',
+};
+
+const darkPalette = {
+    mode: 'dark' as PaletteMode, // 型キャストを追加
+    primary: {
+        main: '#22284F',
+        dark: '#050925',
+        light: '#373e6e',
+    },
+    secondary: {
+        main: '#303560',
+        contrastText: '#eff0f8',
+        dark: '#262b57',
+        light: '#373e6e',
+    },
+    background: {
+        paper: '#22284F',
+        default: '#181D3C',
+    },
+    text: {
+        primary: '#eff0f8',
+        secondary: '#99a5d6',
+        disabled: '#5c628a',
+    },
+    warning: {
+        main: '#b9891a',
+        contrastText: 'rgba(253,252,252,0.87)',
+    },
+    info: { main: '#3a468f' },
+    divider: '#373e6e',
+};
+
+export default function ColorModeProvider({ children }: ColorModeProviderProps) {
+    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+
+    const theme = useMemo(() => createTheme({
+        ...baseTheme,
+        palette: prefersDarkMode ? darkPalette : lightPalette,
+    }), [prefersDarkMode]);
+
+    return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}

--- a/components/theme/colorModeProvider.tsx
+++ b/components/theme/colorModeProvider.tsx
@@ -128,35 +128,35 @@ const lightPalette = {
     divider: '#7f8cd6',
 };
 
-const darkPalette = {
-    mode: 'dark' as PaletteMode, // 型キャストを追加
-    primary: {
-        main: '#8d95c9',
-        dark: '#050925',
-        light: '#373e6e',
-    },
-    secondary: {
-        main: '#303560',
-        contrastText: '#eff0f8',
-        dark: '#262b57',
-        light: '#373e6e',
-    },
-    background: {
-        paper: '#22284F',
-        default: '#181D3C',
-    },
-    text: {
-        primary: '#eff0f8',
-        secondary: '#99a5d6',
-        disabled: '#5c628a',
-    },
-    warning: {
-        main: '#b9891a',
-        contrastText: 'rgba(253,252,252,0.87)',
-    },
-    info: { main: '#3a468f' },
-    divider: '#373e6e',
-};
+// const darkPalette = {
+//     mode: 'dark' as PaletteMode, // 型キャストを追加
+//     primary: {
+//         main: '#8d95c9',
+//         dark: '#050925',
+//         light: '#373e6e',
+//     },
+//     secondary: {
+//         main: '#303560',
+//         contrastText: '#eff0f8',
+//         dark: '#262b57',
+//         light: '#373e6e',
+//     },
+//     background: {
+//         paper: '#22284F',
+//         default: '#181D3C',
+//     },
+//     text: {
+//         primary: '#eff0f8',
+//         secondary: '#99a5d6',
+//         disabled: '#5c628a',
+//     },
+//     warning: {
+//         main: '#b9891a',
+//         contrastText: 'rgba(253,252,252,0.87)',
+//     },
+//     info: { main: '#3a468f' },
+//     divider: '#373e6e',
+// };
 
 export default function ColorModeProvider({ children }: ColorModeProviderProps) {
     const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');

--- a/components/theme/colorModeProvider.tsx
+++ b/components/theme/colorModeProvider.tsx
@@ -101,7 +101,7 @@ const baseTheme = {
 const lightPalette = {
     mode: 'light' as PaletteMode, // 型キャストを追加
     primary: {
-        main: '#EFF0F8',
+        main: '#52598d',
         dark: '#4a5abb',
         light: '#5f6dc2',
     },
@@ -131,7 +131,7 @@ const lightPalette = {
 const darkPalette = {
     mode: 'dark' as PaletteMode, // 型キャストを追加
     primary: {
-        main: '#22284F',
+        main: '#8d95c9',
         dark: '#050925',
         light: '#373e6e',
     },
@@ -163,7 +163,7 @@ export default function ColorModeProvider({ children }: ColorModeProviderProps) 
 
     const theme = useMemo(() => createTheme({
         ...baseTheme,
-        palette: prefersDarkMode ? darkPalette : lightPalette,
+        palette: lightPalette,
     }), [prefersDarkMode]);
 
     return <ThemeProvider theme={theme}>{children}</ThemeProvider>;


### PR DESCRIPTION
### チケット
#9  スマホ対応 
#1  リデザイン

### 概要
- Drawerを改善し、レイアウトをスマホに対応
- スマホ対応に伴い、試合結果入力画面やリーグ表等をレスポンシブ化
- 新しいSPORTSDAY共通のカラーテーマを導入

### 内容
通常の画面サイズでは、左側のメニューバーは固定表示されている。また、新しいカラーテーマが導入されている。
![Screenshot 2024-10-05 at 15 41 34](https://github.com/user-attachments/assets/8ab991a2-1ee5-4be7-8af7-643ac84e55a2)

画面の幅が790px以下になると自動的にハンバーガーメニューとなる。（右が開いた状態）
![Screenshot 2024-10-05 at 15 45 38](https://github.com/user-attachments/assets/9e6b8831-7f7b-440f-99a8-8b95596a2234)

試合結果入力画面がレスポンシブ化された
![Screenshot 2024-10-05 at 15 48 35](https://github.com/user-attachments/assets/24dfedc6-2fdf-4db2-a154-edabdf88b9bf)

新しいログインページ
![Screenshot 2024-10-05 at 15 49 30](https://github.com/user-attachments/assets/a1516327-8eff-488f-bad6-2041306955f2)

ダークモードは一度対応したが、RSC関係？でページ遷移のたびに一瞬ライトモードを挟む不具合が解消できなかったため、後回しにした。