### PR TITLE
勝ち点採点方法を追加

### DIFF
--- a/components/league/legacy/GameEditFields.tsx
+++ b/components/league/legacy/GameEditFields.tsx
@@ -138,6 +138,11 @@ export default function GameEditFields(props: GameEditFieldsProps) {
                     >
                         得失点
                     </MenuItem>
+                    <MenuItem
+                        value={"win_score"}
+                    >
+                        勝ち点
+                    </MenuItem>
                 </Select>
             </FormControl>
 

--- a/components/league/legacy/GameForm.tsx
+++ b/components/league/legacy/GameForm.tsx
@@ -42,8 +42,8 @@ export default function GameForm(props: GameFormProps) {
         }
 
         //  calculationType invalid
-        if (calculationTypeState !== "total_score" && calculationTypeState !== "diff_score") {
-            alert("合計得点もしくは得失点差が選択可能です。")
+        if (calculationTypeState !== "total_score" && calculationTypeState !== "diff_score" && calculationTypeState !== "win_score") {
+            alert("勝ち点、合計得点もしくは得失点差が選択可能です。")
             return
         }
 

--- a/components/league/table/leagueTable.tsx
+++ b/components/league/table/leagueTable.tsx
@@ -126,9 +126,16 @@ export default async function LeagueTable(props: LeagueTableProps) {
                         )
                     }
                 } else {
-                    rows.push(
-                        <TextCell text={`${result.rank.toString()} 位`} key={`result_${i}_${j}`}/>
-                    )
+                    if (results.teams.some(r => r.rank === result.rank && r.teamId !== result.teamId)) {
+                        rows.push(
+                            <TextCell text={`同率 ${result.rank.toString()} 位`} key={`result_${i}_${j}`}/>
+                        )
+                    } else {
+                        rows.push(
+                            <TextCell text={`${result.rank.toString()} 位`} key={`result_${i}_${j}`}/>
+                        )
+                    }
+
                 }
             }
         }

--- a/src/models/GameModel.ts
+++ b/src/models/GameModel.ts
@@ -16,7 +16,7 @@ export type Game = {
 }
 
 export type GameType = "tournament" | "league"
-export type GameCalculationType = "total_score" | "diff_score"
+export type GameCalculationType = "total_score" | "diff_score" | "win_score"
 
 export type TournamentResult = {
     gameId: number,


### PR DESCRIPTION
# 概要

- 得失点や総得点を考慮せずに勝ち点のみで計算を行う採点方法を追加しました
- 順位は同じ場合は「同率〜位」と表示するように変更しました

<img width="311" alt="スクリーンショット 2024-10-08 15 45 54" src="https://github.com/user-attachments/assets/a683371a-ae61-4766-a2d4-d75490f1814b">
